### PR TITLE
Remove check for IOS version, need to modernize.

### DIFF
--- a/src/bin/cfgmaker
+++ b/src/bin/cfgmaker
@@ -170,11 +170,8 @@ sub InterfaceInfo($$$$$) {
 
     my $snmphost = v4onlyifnecessary($router, $routers->{$router}{ipv4only});
 
-    if ($routers->{$router}{deviceinfo}{Vendor} eq 'cisco' &&
-        $routers->{$router}{deviceinfo}{sysDescr} =~ m/Version\s+(\d+\.\d+)/) {
-        push @Variables,  ($1 > 11.0 or $1 < 10.0 ) ? "ifAlias" : "CiscolocIfDescr";
-        if ($1 > 11.2) {push @Variables, "vmVlan";};
-       if ($1 > 11.3) {push @Variables, "vlanTrunkPortDynamicStatus";};
+    if ($routers->{$router}{deviceinfo}{Vendor} eq 'cisco') {
+       push @Variables,  ("ifAlias", "vmVlan", "vlanTrunkPortDynamicStatus");
     } elsif ( $routers->{$router}{deviceinfo}{Vendor} =~ /(?:hp|juniper|dlink|wwp|foundry|dellLan|force10|3com|extremenetworks|openBSD|arista|enterasys|zyxel|vyatta|dcn|brocade|datacom|alcatel|mikrotik|huawei|eltex)/i) {
         push @Variables, "ifAlias";
     }


### PR DESCRIPTION
Cisco IOS version 10.x and 11.x have been retired for some time now. The check is no longer required and conflicts with NXOS Operating system versions which have recently been released (10.2 for example).

This has been tested on:
Catalyst 6500 version 12.2
Catalyst 6500 version 15.5
Catalyst 9300 version 17.6
Nexus 9k NXOS 10.2(3)F.

No errors or incorrect output has been noticed in this environment.